### PR TITLE
remove extra comma after the original_config value

### DIFF
--- a/docker_sign_verify/imageconfig.py
+++ b/docker_sign_verify/imageconfig.py
@@ -60,7 +60,7 @@ class ImageConfig:
                 json.dumps(signature_data["signatures"]),
             )
         if signature_data["original_config"]:
-            result += "{0}:{1},".format(
+            result += "{0}:{1}".format(
                 json.dumps(ImageConfig.ORIGINAL_CONFIG_LABEL),
                 json.dumps(signature_data["original_config"]),
             )


### PR DESCRIPTION
Rich I had an issue using the tool to sign an archive (tar file), and I tracked it down to an extra comma after the original_config tag that is added after the signature.
